### PR TITLE
Make it supports robotframework 2 and 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-robotframework-serverspec2library
+robotframework-serverspeclibrary
 =================================

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'robotframework-serverspeclibrary',
-    version = '0.1',
+    version = '0.2',
     description = 'Server spec on Robot Framework inspired from Serverspec on Ruby',
     url = 'https://github.com/wingyplus/robotframework-serverspeclibrary',
     keywords = 'serverspec robotframework robot',
     license = 'MIT',
     author = 'Thanabodee Charoenpiriyakij',
     author_email = 'wingyminus@gmail.com',
-    install_requires = ['robotframework>=2.8.5', 'paramiko>=1.14.0'],
+    install_requires = ['robotframework>=2.8.5,<3', 'paramiko>=1.14.0'],
     package_dir = {'': 'src'},
     packages = ['ServerSpecLibrary', 'ServerSpecLibrary.keywords']
 )

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'robotframework-serverspeclibrary',
-    version = '0.2',
+    version = '0.1',
     description = 'Server spec on Robot Framework inspired from Serverspec on Ruby',
     url = 'https://github.com/wingyplus/robotframework-serverspeclibrary',
     keywords = 'serverspec robotframework robot',
     license = 'MIT',
     author = 'Thanabodee Charoenpiriyakij',
     author_email = 'wingyminus@gmail.com',
-    install_requires = ['robotframework>=2.8.5,<3', 'paramiko>=1.14.0'],
+    install_requires = ['robotframework>=2.8.5', 'paramiko>=1.14.0'],
     package_dir = {'': 'src'},
     packages = ['ServerSpecLibrary', 'ServerSpecLibrary.keywords']
 )

--- a/src/ServerSpecLibrary/keywords/package.py
+++ b/src/ServerSpecLibrary/keywords/package.py
@@ -9,7 +9,7 @@ class PackageKeyword(object):
         self.builtin.run_keyword(keyword, name, found_package)
 
     def should_be_installed(self, name, found_package):
-        asserts.fail_unless(found_package, 'Package %s not found.' % name)
+        asserts.assert_equal(found_package, 'Package %s not found.' % name)
 
     def should_not_be_installed(self, name, found_package):
-        asserts.fail_if(found_package, 'Found package %s' % name)
+        asserts.assert_false(found_package, 'Found package %s' % name)

--- a/src/ServerSpecLibrary/keywords/package.py
+++ b/src/ServerSpecLibrary/keywords/package.py
@@ -9,7 +9,7 @@ class PackageKeyword(object):
         self.builtin.run_keyword(keyword, name, found_package)
 
     def should_be_installed(self, name, found_package):
-        asserts.assert_equal(found_package, 'Package %s not found.' % name)
+        asserts.assert_true(found_package, 'Package %s not found.' % name)
 
     def should_not_be_installed(self, name, found_package):
         asserts.assert_false(found_package, 'Found package %s' % name)


### PR DESCRIPTION
`fail_unless` and `fail_if` are no longer in robotframework 3. I use `assert_equal` and `assert_fail` instead.